### PR TITLE
Fixed prince example command

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,4 +9,4 @@ The file book.html contains excerpts from a public domain book - [Our Cats by Ha
 
 ### Create a PDF
 
-    > prince -s pdf-styles.css book.html builds/book.pdf
+    > prince -s pdf-styles.css book.html -o builds/book.pdf


### PR DESCRIPTION
I added the missing "-o" option which defines the output file.
The way it is set in the ReadMe version didn't work with the current version of Prince.